### PR TITLE
surcharge -> redéfinit

### DIFF
--- a/src/main/resources/org/sonar/l10n/core_fr.properties
+++ b/src/main/resources/org/sonar/l10n/core_fr.properties
@@ -1612,7 +1612,7 @@ rules_configuration.original_severity=Sévérité initiale
 rules_configuration.original_value=Valeur initiale
 rules_configuration.parent_parameter.empty=vide
 rules_configuration.rule_inherited_from_profile_x=Règle héritée du profil "{0}"
-rules_configuration.rule_overriding_from_profile_x=Cette règle surcharge la définition initiale du profil parent "{0}"
+rules_configuration.rule_overriding_from_profile_x=Cette règle redéfinit la définition initiale du profil parent "{0}"
 sessions.confirm_password=Confirmation du mot de passe
 sessions.new_account=Pas encore membre? <a href="{0}" tabindex="-1">Inscrivez-vous</a> pour créer votre compte.
 sessions.old_account=<a href="{0}" tabindex="-1">Connectez-vous</a> si vous avez déjà un compte.


### PR DESCRIPTION
Au final, la phrase "redéfinit la définition" n'est peut-être pas des plus heureuses, mais au moins c'est une formule plus correcte :-).